### PR TITLE
Feature/293 GitHub datasources should show which

### DIFF
--- a/packages/api/src/services/FileDataSource.service.ts
+++ b/packages/api/src/services/FileDataSource.service.ts
@@ -192,8 +192,7 @@ class FileDataSourceService {
     }
 
     getSearchSnippet(snippet: string, fileName: string) {
-        let temp: string[] = fileName.split('.');
-        let extension: string = temp[temp.length - 1];
+        let extension: string = fileName.split('.').pop();
         if (["java", "cpp", "js", "ts", "vue", "html", "css", "yml", "json", "xml", "py", "php"]
             .indexOf(extension) != -1) {
             //let searchTerm: string = snippet.substring(snippet.indexOf("<6b2f17de-2e79-4d28-899e-a3d02f9cb154open>")

--- a/packages/api/src/services/General.service.ts
+++ b/packages/api/src/services/General.service.ts
@@ -154,7 +154,8 @@ class GeneralService {
                             case "github":
                                 let gitHubOccurrences: any[] = [];
                                 let [gitHubDataSource, gitHubErr] = gitHubDataSourceRepository.getRepoFromFile(key);
-                                if (gitHubErr) {
+                                let [fileInRepo, fileInRepoErr] = gitHubDataSourceRepository.getFileFromRepo(key);
+                                if (gitHubErr || fileInRepoErr) {
                                     continue;
                                 }
                                 // @ts-ignore

--- a/packages/api/src/services/General.service.ts
+++ b/packages/api/src/services/General.service.ts
@@ -153,9 +153,8 @@ class GeneralService {
                                 break;
                             case "github":
                                 let gitHubOccurrences: any[] = [];
-                                let [gitHubDataSource, gitHubErr] = gitHubDataSourceRepository.getRepoFromFile(key);
                                 let [fileInRepo, fileInRepoErr] = gitHubDataSourceRepository.getFileFromRepo(key);
-                                if (gitHubErr || fileInRepoErr) {
+                                if (fileInRepoErr) {
                                     continue;
                                 }
                                 // @ts-ignore
@@ -169,8 +168,8 @@ class GeneralService {
                                 result.push({
                                     "id": key,
                                     "type": currentObject["datasource_type"],
-                                    "source": "https://github.com/" + gitHubDataSource["repo"],
-                                    "datasource_name": gitHubDataSource["repo"].split("/").pop(),
+                                    "source": fileInRepo["file_path"],
+                                    "datasource_name": fileInRepo["file_path"].split("/").pop(),
                                     "datasource_icon": '<svg fill="#ffffff" viewBox="0 0 24 24" width="28px" height="' +
                                         '28px"><path d="M10.9,2.1c-4.6,0.5-8.3,4.2-8.8,8.7c-0.5,4.7,2.2,8.9,6.3,10.5C' +
                                         '8.7,21.4,9,21.2,9,20.8v-1.6c0,0-0.4,0.1-0.9,0.1 c-1.4,0-2-1.2-2.1-1.9c-0.1-0' +

--- a/packages/api/src/services/GitHubDataSource.service.ts
+++ b/packages/api/src/services/GitHubDataSource.service.ts
@@ -125,8 +125,11 @@ class GitHubDataSourceService {
             if (solrErr) {
                 continue;
             }
+            let filePathToStore: string = filePath.replace(repoName + "/", "");
+            filePathToStore = filePathToStore.substring(filePathToStore.split("/")[0].length + 1);
+            filePathToStore = "https://github.com/" + dataSource.repo + "/blob/" + branchName + "/" + filePathToStore;
             const fileFromRepo: FileFromRepo = {
-                filePath: filePath,
+                filePath: filePathToStore,
                 repoUUID: repoUUID,
                 UUID: fileFromRepoUUID
             }

--- a/packages/client/src/views/Search.vue
+++ b/packages/client/src/views/Search.vue
@@ -508,8 +508,8 @@
 </script>
 
 <style scoped>
+  @import "ia-dark.min.css";
 
-  pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}.hljs{color:#ccc;background:#1a1a1a}.hljs ::selection{color:#1d414d}.hljs-comment{color:#767676}.hljs-tag{color:#b8b8b8}.hljs-operator,.hljs-punctuation,.hljs-subst{color:#ccc}.hljs-operator{opacity:.7}.hljs-bullet,.hljs-deletion,.hljs-name,.hljs-selector-tag,.hljs-template-variable,.hljs-variable{color:#d88568}.hljs-attr,.hljs-link,.hljs-literal,.hljs-number,.hljs-symbol,.hljs-variable.constant_{color:#d86868}.hljs-class .hljs-title,.hljs-title,.hljs-title.class_{color:#b99353}.hljs-strong{font-weight:700;color:#b99353}.hljs-addition,.hljs-code,.hljs-string,.hljs-title.class_.inherited__{color:#83a471}.hljs-built_in,.hljs-doctag,.hljs-keyword.hljs-atrule,.hljs-quote,.hljs-regexp{color:#7c9cae}.hljs-attribute,.hljs-function .hljs-title,.hljs-section,.hljs-title.function_,.ruby .hljs-property{color:#8eccdd}.diff .hljs-meta,.hljs-keyword,.hljs-template-tag,.hljs-type{color:#b98eb2}.hljs-emphasis{color:#b98eb2;font-style:italic}.hljs-meta,.hljs-meta .hljs-keyword,.hljs-meta .hljs-string{color:#8b6c37}.hljs-meta .hljs-keyword,.hljs-meta-keyword{font-weight:700}
   .search-bar {
     min-height: 100px;
     border-bottom: solid;

--- a/packages/client/src/views/ia-dark.min.css
+++ b/packages/client/src/views/ia-dark.min.css
@@ -1,0 +1,7 @@
+/*!
+  Theme: iA Dark
+  Author: iA Inc. (modified by aramisgithub)
+  License: ~ MIT (or more permissive) [via base16-schemes-source]
+  Maintainer: @highlightjs/core-team
+  Version: 2021.05.0
+*/pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}.hljs{color:#ccc;background:#1a1a1a}.hljs ::selection{color:#1d414d}.hljs-comment{color:#767676}.hljs-tag{color:#b8b8b8}.hljs-operator,.hljs-punctuation,.hljs-subst{color:#ccc}.hljs-operator{opacity:.7}.hljs-bullet,.hljs-deletion,.hljs-name,.hljs-selector-tag,.hljs-template-variable,.hljs-variable{color:#d88568}.hljs-attr,.hljs-link,.hljs-literal,.hljs-number,.hljs-symbol,.hljs-variable.constant_{color:#d86868}.hljs-class .hljs-title,.hljs-title,.hljs-title.class_{color:#b99353}.hljs-strong{font-weight:700;color:#b99353}.hljs-addition,.hljs-code,.hljs-string,.hljs-title.class_.inherited__{color:#83a471}.hljs-built_in,.hljs-doctag,.hljs-keyword.hljs-atrule,.hljs-quote,.hljs-regexp{color:#7c9cae}.hljs-attribute,.hljs-function .hljs-title,.hljs-section,.hljs-title.function_,.ruby .hljs-property{color:#8eccdd}.diff .hljs-meta,.hljs-keyword,.hljs-template-tag,.hljs-type{color:#b98eb2}.hljs-emphasis{color:#b98eb2;font-style:italic}.hljs-meta,.hljs-meta .hljs-keyword,.hljs-meta .hljs-string{color:#8b6c37}.hljs-meta .hljs-keyword,.hljs-meta-keyword{font-weight:700}


### PR DESCRIPTION
This improves the user experience when searching for GitHub datasources. Each search snippet is associated with a file on GitHub which will open accordingly in the browser.
[GitHub datasources should show which file keywords come from](https://app.gitkraken.com/glo/card/2c919b00e62b4b3b8c3231d8b28e0b68)